### PR TITLE
5.2 compatibility

### DIFF
--- a/classes/AccountType/class.msAccountType.php
+++ b/classes/AccountType/class.msAccountType.php
@@ -40,7 +40,7 @@ class msAccountType {
 
 
 	public function initAccountType() {
-		if ($this->getSubscriptionType() == msSubscription::TYPE_EMAIL AND msConfig::get('shibboleth')) {
+		if ($this->getSubscriptionType() == msSubscription::TYPE_EMAIL AND msConfig::getValueByKey('shibboleth')) {
 			self::readDomains();
 			foreach (self::$domains as $aai) {
 				// (bool)preg_match("/(\\@".$aai.")|(\\@[a-zA-Z0-9]*\\.".$aai.")/uism", $this->getMatchingString()) // Possible Fix fo
@@ -114,7 +114,7 @@ class msAccountType {
 			if (msConfig::checkShibboleth()) {
 				$xslt = new XSLTProcessor();
 				$xslt->importStylesheet(new SimpleXMLElement(file_get_contents('domain_to_idp_entityid.xsl', true)));
-				$metadata = new SimpleXMLElement(file_get_contents(msConfig::get('metadata_xml')));
+				$metadata = new SimpleXMLElement(file_get_contents(msConfig::getValueByKey('metadata_xml')));
 				$xml = simplexml_load_string($xslt->transformToXml($metadata));
 				$domains = array();
 				foreach ($xml->children() as $child) {

--- a/classes/Config/class.msConfig.php
+++ b/classes/Config/class.msConfig.php
@@ -77,7 +77,7 @@ class msConfig extends ActiveRecord {
 	 *
 	 * @return array|string
 	 */
-	public static function get($key) {
+	public static function getValueByKey($key) {
 		$obj = new self($key);
 
 		return $obj->getConfigValue();
@@ -103,7 +103,7 @@ class msConfig extends ActiveRecord {
 	 * @return bool
 	 */
 	public static function checkShibboleth() {
-		return self::get(self::F_SHIBBOLETH) AND is_readable(self::get(self::F_METADATA_XML));
+		return self::getValueByKey(self::F_SHIBBOLETH) AND is_readable(self::getValueByKey(self::F_METADATA_XML));
 	}
 
 
@@ -131,13 +131,13 @@ class msConfig extends ActiveRecord {
 	 */
 	public static function getUsageType() {
 		$usage_type = self::TYPE_NO_USAGE;
-		if (self::get(self::F_USE_EMAIL)) {
+		if (self::getValueByKey(self::F_USE_EMAIL)) {
 			$usage_type = self::TYPE_USAGE_MAIL;
 		}
-		if (self::get(self::F_USE_MATRICULATION)) {
+		if (self::getValueByKey(self::F_USE_MATRICULATION)) {
 			$usage_type = self::TYPE_USAGE_MATRICULATION;
 		}
-		if (self::get(self::F_USE_MATRICULATION) AND self::get(self::F_USE_EMAIL)) {
+		if (self::getValueByKey(self::F_USE_MATRICULATION) AND self::getValueByKey(self::F_USE_EMAIL)) {
 			$usage_type = self::TYPE_USAGE_BOTH;
 		}
 
@@ -151,7 +151,7 @@ class msConfig extends ActiveRecord {
 	 * @return bool
 	 */
 	public static function isInIgnoredSubtree($check_ref_id) {
-		if (! self::get(self::F_IGNORE_SUBTREE_ACTIVE)) {
+		if (! self::getValueByKey(self::F_IGNORE_SUBTREE_ACTIVE)) {
 			return false;
 		}
 		if (isset(self::$ignore_chache[$check_ref_id])) {
@@ -162,7 +162,7 @@ class msConfig extends ActiveRecord {
 		/**
 		 * @var $tree ilTree
 		 */
-		$subtrees = explode(',', self::get(self::F_IGNORE_SUBTREE));
+		$subtrees = explode(',', self::getValueByKey(self::F_IGNORE_SUBTREE));
 		if (! is_array($subtrees) OR count($subtrees) == 0) {
 			self::$ignore_chache[$check_ref_id] = false;
 

--- a/classes/Config/class.msConfigFormGUI.php
+++ b/classes/Config/class.msConfigFormGUI.php
@@ -173,7 +173,7 @@ class msConfigFormGUI extends ilPropertyFormGUI {
 	protected function fillValue($item, $array) {
 		if (get_class($item) != 'ilFormSectionHeaderGUI') {
 			$key = $item->getPostVar();
-			$array[$key] = msConfig::get($key);
+			$array[$key] = msConfig::getValueByKey($key);
 			foreach ($item->getSubItems() as $sub_item) {
 				$array = $this->fillValue($sub_item, $array);
 			}

--- a/classes/Subscription/class.msSubscription.php
+++ b/classes/Subscription/class.msSubscription.php
@@ -110,7 +110,7 @@ class msSubscription extends ActiveRecord {
 				$status = $participants->add($usr_id, $this->getRole());
 				break;
 		}
-		if ($status AND msConfig::get(msConfig::F_SEND_MAILS)) {
+		if ($status AND msConfig::getValueByKey(msConfig::F_SEND_MAILS)) {
 			switch ($this->getContext()) {
 				case self::CONTEXT_CRS:
 					$participants->sendNotification($participants->NOTIFY_ACCEPT_USER, $usr_id);

--- a/classes/Subscription/class.msSubscriptionGUI.php
+++ b/classes/Subscription/class.msSubscriptionGUI.php
@@ -190,14 +190,14 @@ class msSubscriptionGUI {
 		$this->form->setTitle($this->pl->getDynamicTxt('main_form_title_usage_' . msConfig::getUsageType()));
 		//		$this->form->setDescription($this->pl->getDynamicTxt('main_form_info_usage_' . msConfig::getUsageType()));
 		$this->form->setFormAction($this->ctrl->getFormAction($this));
-		if (msConfig::get('use_email')) {
+		if (msConfig::getValueByKey('use_email')) {
 			$te = new ilTextareaInputGUI($this->pl->getDynamicTxt('main_field_emails_title'), self::EMAIL_FIELD);
 			$te->setInfo($this->pl->getDynamicTxt('main_field_emails_info'));
 			$te->setRows(10);
 			$te->setCols(100);
 			$this->form->addItem($te);
 		}
-		if (msConfig::get('use_matriculation')) {
+		if (msConfig::getValueByKey('use_matriculation')) {
 			$te = new ilTextareaInputGUI($this->pl->getDynamicTxt('main_field_matriculation_title'), self::MATRICULATION_FIELD);
 			$te->setInfo($this->pl->getDynamicTxt('main_field_matriculation_info'));
 			$te->setRows(10);
@@ -258,7 +258,7 @@ class msSubscriptionGUI {
 						break;
 					case '':
 					case self::CMD_KEEP:
-						$obj->setDeleted(msConfig::get(msConfig::F_PURGE));
+						$obj->setDeleted(msConfig::getValueByKey(msConfig::F_PURGE));
 						break;
 					case self::CMD_INVITE:
 					case self::CMD_REINVITE:
@@ -272,7 +272,7 @@ class msSubscriptionGUI {
 				$obj->update();
 			}
 		}
-		if (msConfig::get(msConfig::ENBL_INV)) {
+		if (msConfig::getValueByKey(msConfig::ENBL_INV)) {
 			ilUtil::sendInfo($this->pl->getDynamicTxt('main_msg_emails_sent_usage_' . msConfig::getUsageType()), true);
 		} else {
 			ilUtil::sendInfo($this->pl->getDynamicTxt('main_msg_triage_finished'), true);
@@ -302,8 +302,8 @@ class msSubscriptionGUI {
 		/**
 		 * @var $ilUser ilObjUser
 		 */
-		if (msConfig::get(msConfig::F_SYSTEM_USER)) {
-			$mail = new ilMail(msConfig::get(msConfig::F_SYSTEM_USER));
+		if (msConfig::getValueByKey(msConfig::F_SYSTEM_USER)) {
+			$mail = new ilMail(msConfig::getValueByKey(msConfig::F_SYSTEM_USER));
 		} else {
 			$mail = new ilMail(self::SYSTEM_USER);
 		}

--- a/classes/Subscription/class.msSubscriptionTableGUI.php
+++ b/classes/Subscription/class.msSubscriptionTableGUI.php
@@ -74,14 +74,14 @@ class msSubscriptionTableGUI extends msModelObjectTableGUI {
 			$this->addColumn($this->pl->getDynamicTxt('main_tblh_subscription_type'));
 		}
 		$this->addColumn($this->pl->getDynamicTxt('main_tblh_in_ilias'), 'in_ilias');
-		if (msConfig::get(msConfig::F_SHOW_NAMES)) {
+		if (msConfig::getValueByKey(msConfig::F_SHOW_NAMES)) {
 			$this->addColumn($this->pl->getDynamicTxt('main_tblh_name'), 'name');
 		}
 		$this->addColumn($this->pl->getDynamicTxt('main_tblh_status'), 'status_sort');
 
 		$this->addColumn($this->pl->getDynamicTxt('main_tblh_subscribe'));
 
-		if ($this->getMailUsage() AND msConfig::get(msConfig::ENBL_INV)) {
+		if ($this->getMailUsage() AND msConfig::getValueByKey(msConfig::ENBL_INV)) {
 			$this->addColumn($this->pl->getDynamicTxt('main_tblh_invite'));
 		}
 		$this->addColumn($this->pl->getDynamicTxt('main_tblh_role'));
@@ -98,7 +98,7 @@ class msSubscriptionTableGUI extends msModelObjectTableGUI {
 	protected function initFormActionsAndCmdButtons() {
 		$this->addCommandButton('removeUnregistered', $this->pl->getDynamicTxt('main_send_table_remove_unregistered'));
 		$this->addCommandButton('clear', $this->pl->getDynamicTxt('main_send_table_clear'));
-		if (msConfig::get(msConfig::F_USE_EMAIL) AND msConfig::get(msConfig::ENBL_INV)) {
+		if (msConfig::getValueByKey(msConfig::F_USE_EMAIL) AND msConfig::getValueByKey(msConfig::ENBL_INV)) {
 			$this->addCommandButton('triage', $this->pl->getDynamicTxt('main_send_table_usage_2'));
 		} else {
 			$this->addCommandButton('triage', $this->pl->getDynamicTxt('main_send_table_usage_1'));
@@ -185,14 +185,14 @@ class msSubscriptionTableGUI extends msModelObjectTableGUI {
 			$this->tpl->parseCurrentBlock();
 		}
 		$this->tpl->setVariable('STATUS', $this->pl->getDynamicTxt('main_user_status_' . $msSubscription->getUserStatus()));
-		if (msConfig::get('show_names')) {
+		if (msConfig::getValueByKey('show_names')) {
 			$this->tpl->setCurrentBlock('name');
 			$this->tpl->setVariable('NAME', $msSubscription->lookupName());
 			$this->tpl->parseCurrentBlock();
 		}
 		$this->tpl->setVariable('USR_ID', 'obj_' . $msSubscription->getId());
 		$this->tpl->setVariable('STD_ROLE', msUserStatus::ROLE_MEMBER);
-		if (! $this->getMailUsage() OR ! msConfig::get(msConfig::ENBL_INV)) {
+		if (! $this->getMailUsage() OR ! msConfig::getValueByKey(msConfig::ENBL_INV)) {
 			$this->tpl->setVariable('DISABLE_NOMAIL', 'nomail');
 		}
 		$this->tpl->setVariable('CMD_INVITE', msSubscriptionGUI::CMD_INVITE);
@@ -236,7 +236,7 @@ class msSubscriptionTableGUI extends msModelObjectTableGUI {
 				$this->tpl->setVariable('USER_EXISTS_STRING', $this->pl->getDynamicTxt('main_no'));
 				$this->tpl->setVariable('USER_EXISTS_STRING_CLASS', 'no');
 				$this->tpl->setVariable('DISABLED_SUB', self::DISABLED);
-				if (msConfig::get(msConfig::ENBL_INV)) {
+				if (msConfig::getValueByKey(msConfig::ENBL_INV)) {
 					$this->tpl->setVariable('CHECKED_INV', self::CHECKED);
 				} else {
 					$this->tpl->setVariable('CHECKED_INV', self::DISABLED);
@@ -268,7 +268,7 @@ class msSubscriptionTableGUI extends msModelObjectTableGUI {
 	 * @return bool|string
 	 */
 	protected function getMatriculationUsage() {
-		return msConfig::get('use_matriculation');
+		return msConfig::getValueByKey('use_matriculation');
 	}
 
 
@@ -276,7 +276,7 @@ class msSubscriptionTableGUI extends msModelObjectTableGUI {
 	 * @return bool|string
 	 */
 	protected function getMailUsage() {
-		return msConfig::get('use_email');
+		return msConfig::getValueByKey('use_email');
 	}
 }
 

--- a/classes/TokenRegistration/class.ilTokenRegistrationGUI.php
+++ b/classes/TokenRegistration/class.ilTokenRegistrationGUI.php
@@ -89,13 +89,13 @@ class ilTokenRegistrationGUI extends ilAccountRegistrationGUI {
 
 		switch ($this->subscription->getSubscriptionType()) {
 			case msSubscription::TYPE_EMAIL:
-				$usr_email->setDisabled(msConfig::get('fixed_email'));
+				$usr_email->setDisabled(msConfig::getValueByKey('fixed_email'));
 				$usr_email->setValue($this->subscription->getMatchingString());
 				$retype = in_array('setRetypeValue', get_class_methods(get_class($usr_email)));
 				if ($retype) {
 					$usr_email->setRetypeValue($this->subscription->getMatchingString());
 				}
-				if (msConfig::get('fixed_email')) {
+				if (msConfig::getValueByKey('fixed_email')) {
 					//					$usr_email->setPostVar('usr_email_fixed');
 					$hidden = new ilHiddenInputGUI('usr_email');
 					$hidden->setValue($this->subscription->getMatchingString());
@@ -108,7 +108,7 @@ class ilTokenRegistrationGUI extends ilAccountRegistrationGUI {
 				}
 				break;
 			case msSubscription::TYPE_MATRICULATION:
-				$matriculation->setDisabled(msConfig::get('fixed_email'));
+				$matriculation->setDisabled(msConfig::getValueByKey('fixed_email'));
 				$matriculation->setValue($this->subscription->getMatchingString());
 		}
 	}

--- a/classes/Triage/class.subscrTriageGUI.php
+++ b/classes/Triage/class.subscrTriageGUI.php
@@ -68,7 +68,7 @@ class subscrTriageGUI {
 
 
 	public function start() {
-		if (msConfig::get('ask_for_login')) {
+		if (msConfig::getValueByKey('ask_for_login')) {
 			if ($this->subscription->getAccountType() == msAccountType::TYPE_SHIBBOLETH) {
 				ilUtil::sendInfo('Ihre E-Mailadresse wurde als SwitchAAI-Adresse erkannt. Sie können sich direkt einloggen. Klicken Sie auf Login und wählen Sie Ihre Home-Organisation aus.');
 				$this->tpl->setContent('<a href="' . $this->getLoginLonk() . '" class="submit">Login</a>');
@@ -108,7 +108,7 @@ class subscrTriageGUI {
 		) {
 			$this->redirectToLogin();
 		} else {
-			if (msConfig::get('allow_registration')) {
+			if (msConfig::getValueByKey('allow_registration')) {
 				$this->redirectToTokenRegistrationGUI();
 			} else {
 				$this->redirectToLogin();

--- a/classes/UserStatus/class.msUserStatus.php
+++ b/classes/UserStatus/class.msUserStatus.php
@@ -105,7 +105,7 @@ class msUserStatus {
 
 				return;
 			} else {
-				if (msConfig::get(msConfig::ENBL_INV)) {
+				if (msConfig::getValueByKey(msConfig::ENBL_INV)) {
 					$this->setStatus(self::STATUS_USER_CAN_BE_INVITED);
 				} else {
 					$this->setStatus(self::STATUS_USER_NOT_ASSIGNABLE);

--- a/classes/class.ilSubscriptionUIHookGUI.php
+++ b/classes/class.ilSubscriptionUIHookGUI.php
@@ -68,9 +68,12 @@ class ilSubscriptionUIHookGUI extends ilUIHookPluginGUI {
 			array( 'ilobjgroupgui', 'deleteMembers' ),
 			array( 'ilrepositorysearchgui', '*' ),
 			array( 'ilmemberexportgui', '*' ),
+            array( 'ilcoursemembershipgui', '*' ),
+            array( 'ilgroupmembershipgui', '*' ),
 		);
 
 		$tab_highlight = array( array( 'ilsubscriptiongui', '*' ), );
+
 		if ($this->checkContext($a_part, $locations)) {
 			$pl_obj = ilSubscriptionPlugin::getInstance();
 			$this->tabs->removeSubTab('srsubscription');
@@ -120,7 +123,6 @@ class ilSubscriptionUIHookGUI extends ilUIHookPluginGUI {
 		$check_cmd = in_array(array( $this->ctrl->getCmdClass(), $this->ctrl->getCmd() ), $context);
 		$check_cmd_class = in_array(array( $this->ctrl->getCmdClass(), '*' ), $context);
 		if (!$check_cmd AND !$check_cmd_class) {
-
 			return false;
 		}
 		if (!in_array($this->ctrl->getContextObjType(), array( 'grp', 'crs' ))) {
@@ -132,7 +134,7 @@ class ilSubscriptionUIHookGUI extends ilUIHookPluginGUI {
 			return false;
 		}
 
-		if ($this->ctrl->getContextObjType() == 'grp' AND !msConfig::get(msConfig::F_ACTIVATE_GROUPS)) {
+		if ($this->ctrl->getContextObjType() == 'grp' AND !msConfig::getValueByKey(msConfig::F_ACTIVATE_GROUPS)) {
 			return false;
 		}
 
@@ -180,7 +182,7 @@ class ilSubscriptionUIHookGUI extends ilUIHookPluginGUI {
 		if (!isset(self::$ignored_subtree)) {
 			global $tree;
 
-			foreach (explode(',', trim(msConfig::get('ignore_subtree'))) as $root_id) {
+			foreach (explode(',', trim(msConfig::getValueByKey('ignore_subtree'))) as $root_id) {
 				if (!$root_id) {
 					continue;
 				}

--- a/classes/triage.php
+++ b/classes/triage.php
@@ -113,7 +113,7 @@ class msTriage {
 
 
 	public function start() {
-		if (msConfig::get('ask_for_login')) {
+		if (msConfig::getValueByKey('ask_for_login')) {
 			$this->showLoginDecision();
 		} else {
 			$this->determineLogin();
@@ -150,7 +150,7 @@ class msTriage {
 		) {
 			$this->redirectToLogin();
 		} else {
-			if (msConfig::get('allow_registration')) {
+			if (msConfig::getValueByKey('allow_registration')) {
 				$this->redirectToTokenRegistrationGUI();
 			} else {
 				$this->redirectToLogin();

--- a/plugin.php
+++ b/plugin.php
@@ -1,8 +1,8 @@
 <?php
 $id = 'subscription';
-$version = '2.6.1';
+$version = '2.6.2';
 $ilias_min_version = '4.4.0';
-$ilias_max_version = '5.1.999';
+$ilias_max_version = '5.2.999';
 $responsible = 'Fabian Schmid, Oskar Truffer - studer + raimann ag';
 $responsible_mail = 'support@studer-raimann.ch';
 ?>


### PR DESCRIPTION
 had to change get() to getValueByKey() to suppress the error of it being incompatible with ActiveRecords get().

As well I had to add two more areas of context 

```
   array( 'ilcoursemembershipgui', '*' ), 
   array( 'ilgroupmembershipgui', '*' ),

```
I'm unsure if this removes the need for old contexts in the ilobjgroupgui and ilobjcoursegui, but I left them in there for now.

Tested and working in my copy of Ilias 5.2