### PR TITLE
Update class.ilSubscriptionUIHookGUI.php

### DIFF
--- a/classes/class.ilSubscriptionUIHookGUI.php
+++ b/classes/class.ilSubscriptionUIHookGUI.php
@@ -96,7 +96,6 @@ class ilSubscriptionUIHookGUI extends ilUIHookPluginGUI
             $tabs->removeSubTab(self::TAB_SRSUBSCRIPTION);
             $tabs->activateTab(self::TAB_MEMBERS);
             $this->ctrl->setTargetScript('ilias.php');
-            $this->initBaseClass();
             $this->ctrl->setParameterByClass(msSubscriptionGUI::class, 'obj_ref_id', $_GET[self::REF_ID]);
 
             $tabs->addSubTab(


### PR DESCRIPTION
Calling $this->ctrl->initBaseClass() at this point will cause cmdClass to be an empty string.  This is causing problems for any UIHook Plugins that come after the Subscription plugin and are also creating a Sub tab in ilcoursemembershipgui.  In our case any plugins that came after Subscription were unable to also create a subtab. The Subscription plugin also seems to work without this line.